### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/battery_state_broadcaster/CMakeLists.txt
+++ b/battery_state_broadcaster/CMakeLists.txt
@@ -14,16 +14,23 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-foreach(dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
-  find_package(${dependency} REQUIRED)
-endforeach()
+find_package(controller_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(realtime_tools REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 add_library(battery_state_broadcaster SHARED src/BatteryStateBroadcaster.cpp)
 target_include_directories(battery_state_broadcaster PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/battery_state_broadcaster>
 )
-ament_target_dependencies(battery_state_broadcaster PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(battery_state_broadcaster
+  PUBLIC
+    controller_interface::controller_interface
+    pluginlib::pluginlib
+    realtime_tools::realtime_tools
+    ${sensor_msgs_TARGETS}
+)
 
 pluginlib_export_plugin_description_file(controller_interface battery_state_broadcaster.xml)
 

--- a/battery_state_rviz_overlay/CMakeLists.txt
+++ b/battery_state_rviz_overlay/CMakeLists.txt
@@ -13,10 +13,13 @@ find_package(rviz_2d_overlay_msgs REQUIRED)
 find_package(fmt REQUIRED)
 
 add_executable(battery_state_rviz_overlay src/main.cpp src/BatteryStateDisplay.cpp)
-ament_target_dependencies(battery_state_rviz_overlay rclcpp sensor_msgs rviz_2d_overlay_msgs)
+target_link_libraries(battery_state_rviz_overlay
+ rclcpp::rclcpp
+ ${sensor_msgs_TARGETS}
+ ${rviz_2d_overlay_msgs_TARGETS}
+)
 target_include_directories(battery_state_rviz_overlay PRIVATE include)
 target_link_libraries(battery_state_rviz_overlay fmt::fmt)
-
 
 install(
   TARGETS battery_state_rviz_overlay


### PR DESCRIPTION
`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.

Debs build is broken https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__battery_state_rviz_overlay__ubuntu_noble_amd64__binary/