### PR TITLE
Fix battery percentage scale

### DIFF
--- a/battery_state_rviz_overlay/src/BatteryStateDisplay.cpp
+++ b/battery_state_rviz_overlay/src/BatteryStateDisplay.cpp
@@ -46,7 +46,7 @@ void BatteryStateDisplay::batteryStateCallback(const sensor_msgs::msg::BatterySt
 
   if (isNormal(message.percentage))
   {
-    overlay.text += fmt::format(FMT_COMPILE("Percent SOC:     {:>8.2f}%\n"), message.percentage);
+    overlay.text += fmt::format(FMT_COMPILE("Percent SOC:     {:>8.2f}%\n"), 100 * message.percentage);
     overlay.height += line_height;
   }
 


### PR DESCRIPTION
In the BatteryState message the percentage is documented as follows:

> float32 percentage       # Charge percentage on 0 to 1 range  (If unmeasured NaN)

This means we must multiply by 100 before displaying in rviz.

```
ros2 topic echo /battery_state
...
percentage: 0.9719999432563782
...
```

Result, after this PR:
<img width="272" height="76" alt="Screenshot from 2025-12-03 15-56-56" src="https://github.com/user-attachments/assets/6d59ef83-f031-40d7-8bd1-607565ded83a" />
