### PR TITLE
Fix compile error with latest realtime_tools

### DIFF
--- a/battery_state_broadcaster/include/battery_state_broadcaster/BatteryStateBroadcaster.hpp
+++ b/battery_state_broadcaster/include/battery_state_broadcaster/BatteryStateBroadcaster.hpp
@@ -30,5 +30,6 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::BatteryState>::SharedPtr battery_state_pub_;
   std::unique_ptr<BatterySensor> battery_sensor_;
   std::unique_ptr<realtime_tools::RealtimePublisher<sensor_msgs::msg::BatteryState>> realtime_publisher_;
+  sensor_msgs::msg::BatteryState msg_;
 };
 }  // namespace battery_state_broadcaster

--- a/battery_state_broadcaster/src/BatteryStateBroadcaster.cpp
+++ b/battery_state_broadcaster/src/BatteryStateBroadcaster.cpp
@@ -25,27 +25,27 @@ BatteryStateBroadcaster::on_configure(const rclcpp_lifecycle::State& /*previous_
   realtime_publisher_ =
       std::make_unique<realtime_tools::RealtimePublisher<sensor_msgs::msg::BatteryState>>(battery_state_pub_);
 
-  realtime_publisher_->msg_.temperature = std::numeric_limits<double>::quiet_NaN();
-  realtime_publisher_->msg_.current = std::numeric_limits<double>::quiet_NaN();
-  realtime_publisher_->msg_.charge = std::numeric_limits<double>::quiet_NaN();
-  realtime_publisher_->msg_.capacity = std::numeric_limits<double>::quiet_NaN();
-  realtime_publisher_->msg_.design_capacity = std::numeric_limits<double>::quiet_NaN();
-  realtime_publisher_->msg_.percentage = std::numeric_limits<double>::quiet_NaN();
-  realtime_publisher_->msg_.power_supply_status = sensor_msgs::msg::BatteryState::POWER_SUPPLY_STATUS_UNKNOWN;
-  realtime_publisher_->msg_.power_supply_health = sensor_msgs::msg::BatteryState::POWER_SUPPLY_HEALTH_UNKNOWN;
-  realtime_publisher_->msg_.power_supply_technology = sensor_msgs::msg::BatteryState::POWER_SUPPLY_TECHNOLOGY_UNKNOWN;
-  realtime_publisher_->msg_.present = true;
+  msg_.temperature = std::numeric_limits<double>::quiet_NaN();
+  msg_.current = std::numeric_limits<double>::quiet_NaN();
+  msg_.charge = std::numeric_limits<double>::quiet_NaN();
+  msg_.capacity = std::numeric_limits<double>::quiet_NaN();
+  msg_.design_capacity = std::numeric_limits<double>::quiet_NaN();
+  msg_.percentage = std::numeric_limits<double>::quiet_NaN();
+  msg_.power_supply_status = sensor_msgs::msg::BatteryState::POWER_SUPPLY_STATUS_UNKNOWN;
+  msg_.power_supply_health = sensor_msgs::msg::BatteryState::POWER_SUPPLY_HEALTH_UNKNOWN;
+  msg_.power_supply_technology = sensor_msgs::msg::BatteryState::POWER_SUPPLY_TECHNOLOGY_UNKNOWN;
+  msg_.present = true;
 
   int64_t psu_tech = get_node()->get_parameter("power_supply_technology").as_int();
   if (psu_tech != -1)
   {
-    realtime_publisher_->msg_.power_supply_technology = psu_tech;
+    msg_.power_supply_technology = psu_tech;
   }
 
   double design_capacity = get_node()->get_parameter("design_capacity").as_double();
   if (design_capacity != 0.0)
   {
-    realtime_publisher_->msg_.design_capacity = static_cast<float>(design_capacity);
+    msg_.design_capacity = static_cast<float>(design_capacity);
   }
 
   return CallbackReturn::SUCCESS;
@@ -86,7 +86,6 @@ controller_interface::return_type BatteryStateBroadcaster::update(const rclcpp::
 {
   if (realtime_publisher_)
   {
-    sensor_msgs::msg::BatteryState msg_;
     msg_.header.stamp = time;
     battery_sensor_->get_values_as_message(msg_);
     realtime_publisher_->try_publish(msg_);


### PR DESCRIPTION
[Recent commit in realtime_tools](https://github.com/ros-controls/realtime_tools/pull/423/commits/9e26e41bc49f9439cc9754bd5941c615a8599098) causes the following compilation failure in rolling distro:

    battery_state_broadcaster/src/BatteryStateBroadcaster.cpp:28:24:
    error: ‘sensor_msgs::msg::BatteryState_<std::allocator<void> >
    realtime_tools::RealtimePublisher<sensor_msgs::msg::BatteryState_<std::allocator<void>
    > >::msg_’ is private within this context

This PR fixes that, but it was only compile-tested.

